### PR TITLE
more better generic resource!

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,4 +1,5 @@
 const { join } = require('path')
+const step = require('callstep')
 
 const { Stack } = require('../')
 
@@ -8,10 +9,11 @@ const stack = Stack({
   debug: true
 })
 
-stack.up(config)(err => {
+step.series([
+  stack.up(config),
+  stack.up(config),
+  stack.down(config),
+  stack.down(config)
+])(err => {
   if (err) throw err
-
-  stack.down(config)(err => {
-    if (err) throw err
-  })
 })

--- a/package.json
+++ b/package.json
@@ -71,9 +71,6 @@
     "pino": "^4.16.1",
     "pino-colada": "^1.4.4",
     "pumpify": "^1.4.0",
-    "run-parallel": "^1.1.9",
-    "run-series": "^1.1.8",
-    "run-waterfall": "^1.1.6",
     "simple-get": "^3.0.2"
   }
 }

--- a/resources/network.js
+++ b/resources/network.js
@@ -1,3 +1,7 @@
 const generic = require('./generic')
 
-module.exports = generic('network')
+module.exports = generic({
+  name: 'network',
+  hasUpdate: false,
+  idField: 'Id'
+})

--- a/resources/service.js
+++ b/resources/service.js
@@ -1,4 +1,7 @@
 const generic = require('./generic')
 
-// TODO isUpdatable: true
-module.exports = generic('service')
+module.exports = generic({
+  name: 'service',
+  hasUpdate: true,
+  idField: 'ID'
+})

--- a/resources/volume.js
+++ b/resources/volume.js
@@ -1,3 +1,7 @@
 const generic = require('./generic')
 
-module.exports = generic('volume')
+module.exports = generic({
+  name: 'volume',
+  hasUpdate: false,
+  idField: 'Name'
+})


### PR DESCRIPTION
the plan was to add `update` for services, but along the way i realized many things were broken:

- each resource uses a different identifier!
- `down` should check if resource exists before `remove`
- `up` returns output of inspect

generic resource creator now takes:

- `name`
- `hasUpdate`: true for `service`, false otherwise
- `idField`: network uses `Id, volume only has `Name`, service uses `ID`